### PR TITLE
update to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,5 +36,5 @@ inputs:
     required: false
     default: 'id_rsa'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "configure-build-credentials",
-  "version": "1.0.0",
-  "lockfileVersion": 2,
+  "version": "2.0.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "node_modules/@actions/core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "configure-build-credentials",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "configure-build-credentials",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
         "@actions/core": "^1.10.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configure-build-credentials",
-  "version": "1.8.0",
+  "version": "2.0.0",
   "description": "Configure common credentials for Onshape build environments",
   "main": "index.js",
   "author": "Mark Barr",


### PR DESCRIPTION
### ISSUE
Deprecation warnings in GitHub workflows
```
Annotations
1 warning
patch
Node.js 16 actions are deprecated. 
Please update the following actions to use Node.js 20: actions/checkout@v3, onshape/configure-build-credentials@v1.8.
For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

### CHANGE
- Updated to use node 20
- Run `npm i --package-lock-only` to update
- Updated package `onshape/configure-build-credentials` to 2.0.0 because of the major change

NOTE: I will tag this v2.0, usage`uses: onshape/configure-build-credentials@v2.0`

### TESTING
- https://github.com/onshape/meld/actions/runs/7717688507
```
      - name: Configure Build Credentials
        uses: onshape/configure-build-credentials@sgile-node20
```