### PR TITLE
configure-build-credentials: add signed-commits-email

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ typings/
 # dotenv environment variables file
 .env
 
+# Visual Studio Code
+.vscode/

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ The SSH key name, Default: `"id_rsa"`
 
 The SSH known_hosts file contents
 
+#### `signed-commits-email`
+
+Set up sign commits
+
+**Required** To create signed commits you must specify `ssh-key-name` and `ssh-key`
 
 ## Example usage
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,9 @@ inputs:
   ssh-known-hosts:
     description: 'SSH Known Hosts data'
     required: false
+  signed-commits-email:
+    description: 'Set up signed commits using the email specified'
+    required: false
 runs:
   using: 'node20'
   main: 'index.js'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configure-build-credentials",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Configure common credentials for Onshape build environments",
   "main": "index.js",
   "author": "Mark Barr",


### PR DESCRIPTION
Tested:
- eslint, yamllint, jsonlint
- tagged this commit as v2.2 and used it in this test workflow, noting no bypasses were needed and the test commit it made was signed: https://github.com/onshape/test-actions/actions/runs/15193046088/job/42730405199