### PR TITLE
Ensure the SSH key has a newline at the end

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,8 @@ async function configureSshKey () {
   await fs.mkdir(directory, { recursive: true });
 
   const file = join(directory, INPUT_SSH_KEY_NAME);
-  await fs.writeFile(file, INPUT_SSH_KEY);
+  const keyWithNewline = INPUT_SSH_KEY.endsWith('\n') ? INPUT_SSH_KEY : INPUT_SSH_KEY + '\n';
+  await fs.writeFile(file, keyWithNewline);
   await fs.chmod(file, DEFAULT_FILE_MODE);
 
   console.log(`Configured SSH key "${ INPUT_SSH_KEY_NAME }"`);


### PR DESCRIPTION
Without a newline `ssh-keygen` will fail with `Load key "/home/runner/.ssh/id_rsa": error in libcrypto` for a new `ed25519` key I just added.

Checked this worked with both the new key (`BUILDMASTER_SHADOW_SSH_KEY`) and the existing  RSA one (`BUILDMASTER_SSH_KEY`).

